### PR TITLE
Delay loading of stalk to avoid visual bug

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -49,7 +49,10 @@
 		-webkit-text-size-adjust: 100%;
  }
 
-
+  #stalk {
+    opacity: 0;
+    transition: all 2s ease-in;
+  }
 /* #Typography
 ================================================== */
 	h1, h2, h3, h4, h5, h6 {

--- a/scripts/launch.js
+++ b/scripts/launch.js
@@ -7,6 +7,10 @@ $(document).ready(function() {
    	var windowHeight = $(window).height();
 	var windowWidth = $(window).width();
 
+  setTimeout(function(){
+    $('#stalk').css('opacity', '1');
+  }, 1000);
+
 	$(".variation").click(function(){
 		var url = $(this).attr("data-url");
 		window.open(url, "_self");


### PR DESCRIPTION
I delayed by 1 second after page load, the visibility of the #stalk element. Not optimal at all, but this will prevent the visual issue you were encountering.